### PR TITLE
Implemented ability to use a canvas only instead of rendering an image

### DIFF
--- a/JsBarcode.js
+++ b/JsBarcode.js
@@ -17,8 +17,23 @@
 		options = merge(JsBarcode.defaults, options);
 
 		//Create the canvas where the barcode will be drawn on
-		var canvas = document.createElement('canvas');
-		
+		// Check if the given image is already a canvas
+		var canvas = image;
+
+		// check if it is a jQuery selection
+		if (image instanceof jQuery) {
+			// get the DOM element of the selection
+			canvas = image.get(0);
+			// check if DOM element is a canvas, otherwise it will be probably an image so create a canvas
+			if (!(canvas instanceof HTMLCanvasElement)) {
+				canvas = document.createElement('canvas');
+			}
+		} else if (!(image instanceof HTMLCanvasElement)) {
+			// there is no jQuery selection so just check if DOM element is a canvas, otherwise it will be probably
+			// an image so create a canvas
+			canvas = document.createElement('canvas');
+		}
+
 		//Abort if the browser does not support HTML5canvas
 		if (!canvas.getContext) {
 			return image;
@@ -88,12 +103,16 @@
 		
 		//Grab the dataUri from the canvas
 		uri = canvas.toDataURL('image/png');
-		
-		//Put the data uri into the image
-		if (image.attr) { //If element has attr function (jQuery element)
-			return image.attr("src", uri);
-		}
-		else { //DOM element
+
+		// check if given image is a jQuery selection
+		if (image instanceof jQuery) {
+			// check if the given image was a canvas, if not set the source attribute of the image
+			if (!(image.get(0) instanceof HTMLCanvasElement)) {
+				//Put the data uri into the image
+				return image.attr("src", uri);
+			}
+		} else if (!(image instanceof HTMLCanvasElement)) {
+			// There is no jQuery selection so just check if the given image was a canvas, if not set the source attr
 			image.setAttribute("src", uri);
 		}
 

--- a/JsBarcode.js
+++ b/JsBarcode.js
@@ -20,17 +20,14 @@
 		// Check if the given image is already a canvas
 		var canvas = image;
 
-		// check if it is a jQuery selection
-		if (image instanceof jQuery) {
-			// get the DOM element of the selection
+		// check if it is a jQuery object
+		if (canvas instanceof jQuery) {
+			// get the DOM element of the object
 			canvas = image.get(0);
-			// check if DOM element is a canvas, otherwise it will be probably an image so create a canvas
-			if (!(canvas instanceof HTMLCanvasElement)) {
-				canvas = document.createElement('canvas');
-			}
-		} else if (!(image instanceof HTMLCanvasElement)) {
-			// there is no jQuery selection so just check if DOM element is a canvas, otherwise it will be probably
-			// an image so create a canvas
+		}
+
+		// check if DOM element is a canvas, otherwise it will be probably an image so create a canvas
+		if (!(canvas instanceof HTMLCanvasElement)) {
 			canvas = document.createElement('canvas');
 		}
 
@@ -104,15 +101,15 @@
 		//Grab the dataUri from the canvas
 		uri = canvas.toDataURL('image/png');
 
-		// check if given image is a jQuery selection
+		// check if given image is a jQuery object
 		if (image instanceof jQuery) {
-			// check if the given image was a canvas, if not set the source attribute of the image
+			// check if DOM element of jQuery selection is not a canvas, so assume that it is an image
 			if (!(image.get(0) instanceof HTMLCanvasElement)) {
-				//Put the data uri into the image
-				return image.attr("src", uri);
+				 //Put the data uri into the image
+			 	return image.attr("src", uri);
 			}
 		} else if (!(image instanceof HTMLCanvasElement)) {
-			// There is no jQuery selection so just check if the given image was a canvas, if not set the source attr
+			// There is no jQuery object so just check if the given image was a canvas, if not set the source attr
 			image.setAttribute("src", uri);
 		}
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ JsBarcode(object, string, options);
 Examples
 ----
 
-####First we need an image
+####First we need an image (or an canvas - it works both ways!)
 ````html
 <img id="barcode">
+````
+or
+````html
+<canvas id="barcode"></canvas
 ````
 
 #### This code:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ JsBarcode(object, string, options);
 Examples
 ----
 
-####First we need an image (or an canvas - it works both ways!)
+####First we need an image (or a canvas - it works both ways!)
 ````html
 <img id="barcode">
 ````


### PR DESCRIPTION
I have added the ability to pass a canvas instead of an image to the library, in which the barcode gets rendered.  All functionality for passing an image and rendering the output to, is kept untouched. I have just improved the test if jQuery is present.