### PR TITLE
Make JsBarcode core IE8-compatible.

### DIFF
--- a/JsBarcode.js
+++ b/JsBarcode.js
@@ -1,7 +1,11 @@
 (function($){
-	
+
+	function isCanvasElement(el) {
+		return el.tagName.toUpperCase() === 'CANVAS';
+	}
+
 	JsBarcode = function(image, content, options, validFunction) {
-		
+
 		var merge = function(m1, m2) {
 			var newMerge = {};
 			for (var k in m1) {
@@ -15,11 +19,11 @@
 
 		//This tries to call the valid function only if it's specified. Otherwise nothing happens
 		var validFunctionIfExist = function(valid){
-		    if(validFunction){
-		        validFunction(valid);
-		    }
+			if(validFunction){
+				validFunction(valid);
+			}
 		};
-	
+
 		//Merge the user options with the default
 		options = merge(JsBarcode.defaults, options);
 
@@ -34,7 +38,7 @@
 		}
 
 		// check if DOM element is a canvas, otherwise it will be probably an image so create a canvas
-		if (!(canvas instanceof HTMLCanvasElement)) {
+		if (!isCanvasElement(canvas)) {
 			canvas = document.createElement('canvas');
 		}
 
@@ -42,92 +46,89 @@
 		if (!canvas.getContext) {
 			return image;
 		}
-		
+
 		var encoder = new window[options.format](content);
-		
+
 		//Abort if the barcode format does not support the content
 		if(!encoder.valid()){
-		    validFunctionIfExist(false);
+				validFunctionIfExist(false);
 			return this;
 		}
-		
+
 		//Encode the content
 		var binary = encoder.encoded();
-		
+
 		var _drawBarcodeText = function (text) {
-					var x, y;
+			var x, y;
 
-					y = options.height;
+			y = options.height;
 
-					ctx.font = options.fontSize + "px "+options.font;
-					ctx.textBaseline = "bottom";
-					ctx.textBaseline = 'top';
+			ctx.font = options.fontSize + "px "+options.font;
+			ctx.textBaseline = "bottom";
+			ctx.textBaseline = 'top';
 
-					if(options.textAlign == "left"){
-						x = options.quite;
-						ctx.textAlign = 'left';
-					}
-					else if(options.textAlign == "right"){
-						x = canvas.width - options.quite;
-						ctx.textAlign = 'right';
-					}
-					else{ //All other center
-						x = canvas.width / 2;
-						ctx.textAlign = 'center';
-					}
+			if(options.textAlign == "left"){
+				x = options.quite;
+				ctx.textAlign = 'left';
+			}
+			else if(options.textAlign == "right"){
+				x = canvas.width - options.quite;
+				ctx.textAlign = 'right';
+			}
+			else{ //All other center
+				x = canvas.width / 2;
+				ctx.textAlign = 'center';
+			}
 
-					ctx.fillText(text, x, y);
-				}
-		
+			ctx.fillText(text, x, y);
+		}
+
 		//Get the canvas context
 		var ctx	= canvas.getContext("2d");
-		
+
 		//Set the width and height of the barcode
 		canvas.width = binary.length*options.width+2*options.quite;
-        //Set extra height if the value is displayed under the barcode. Multiplication with 1.3 t0 ensure that some
-        //characters are not cut in half
+				//Set extra height if the value is displayed under the barcode. Multiplication with 1.3 t0 ensure that some
+				//characters are not cut in half
 		canvas.height = options.height + (options.displayValue ? options.fontSize * 1.3 : 0);
-		
+
 		//Paint the canvas
 		ctx.clearRect(0,0,canvas.width,canvas.height);
 		if(options.backgroundColor){
 			ctx.fillStyle = options.backgroundColor;
 			ctx.fillRect(0,0,canvas.width,canvas.height);
 		}
-		
+
 		//Creates the barcode out of the encoded binary
 		ctx.fillStyle = options.lineColor;
 		for(var i=0;i<binary.length;i++){
 			var x = i*options.width+options.quite;
 			if(binary[i] == "1"){
 				ctx.fillRect(x,0,options.width,options.height);
-			}			
+			}
 		}
-		
+
 		if(options.displayValue){
 			_drawBarcodeText(content);
 		}
-		
-		//Grab the dataUri from the canvas
-		uri = canvas.toDataURL('image/png');
 
 		// check if given image is a jQuery object
 		if (window.jQuery && image instanceof jQuery) {
 			// check if DOM element of jQuery selection is not a canvas, so assume that it is an image
-			if (!(image.get(0) instanceof HTMLCanvasElement)) {
+			if (!isCanvasElement(image.get(0))) {
 				 //Put the data uri into the image
-			 	image.attr("src", uri);
+				image.attr("src", canvas.toDataURL('image/png'));
 			}
-		} else if (!(image instanceof HTMLCanvasElement)) {
+		} else if (!isCanvasElement(image)) {
 			// There is no jQuery object so just check if the given image was a canvas, if not set the source attr
-			image.setAttribute("src", uri);
+			image.setAttribute("src", canvas.toDataURL('image/png'));
 		}
 
 
 		validFunctionIfExist(true);
 
 	};
-	
+
 	JsBarcode.defaults = {
 		width:	2,
 		height:	100,


### PR DESCRIPTION
`HTMLCanvasElement` is undefined on IE8 even in the presence of a shim like excanvas, so I switched the instanceOf checks to test the `tagName`. In addition, the `toDataUri` method is missing in the excanvas shim - I have moved this inside of the various if statements as there is usually no need to call this.

This also fixes several whitespace and tabbing issues.