### PR TITLE
fix ff blurry rendering

### DIFF
--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -114,7 +114,7 @@ function drawSVGText(parent, options, encoding){
     var x, y;
 
     textElem.setAttribute("style",
-      "font:" + options.fontOptions + " " + options.fontSize + "px " + options.font
+      "font:" + options.fontOptions + " " + options.fontSize + "px " + options.font + ";transform:translate(0,0);"
     );
 
     if(options.textPosition == "top"){


### PR DESCRIPTION
attempted fix at firefox pixel perfect rendering (fixing #64)

This will need a lot of testing.

half pixel spacing means that firefox renders SVG lines over 2 pixels, causing blur. centering (transforming) around 0,0 should fix this issue.