### PR TITLE
Correct invalid ITF14 checksum

### DIFF
--- a/src/barcodes/ITF14/index.js
+++ b/src/barcodes/ITF14/index.js
@@ -67,7 +67,7 @@ class ITF14{
 			result += parseInt(this.string[i]) * (3 - (i % 2) * 2);
 		}
 
-		return 10 - (result % 10);
+		return Math.ceil(result / 10) * 10 - result;
 	}
 }
 


### PR DESCRIPTION
The following are valid ITF-14 codes that do not pass the original checksum implementation:

* 00847280031740
* 00847280031900
* 00847280032020
* 00847280031870
* 00847280031450
* 00847280031320

The error comes when the sum of the check digits is a multiple of 10 (e.g. 100):

    return 10 - (result % 10);
    return 10 - (100 % 10);
    return 10 - 0;
    return 10; // This should really be return 0;

An easy correction is to calculate the next highest power of 10, and subtract the result from that, as per the GS1 Spec (http://www.gs1.org/how-calculate-check-digit-manually).

Without this in place, the barcode implementation is effectively broken.