### PR TITLE
Add support for Codabar format

### DIFF
--- a/src/barcodes/codabar/index.js
+++ b/src/barcodes/codabar/index.js
@@ -5,7 +5,7 @@ class codabar{
 	constructor(string){
 		this.string = string.toUpperCase();
 
-		if (this.string.search(/^[0-9\-\$\:\.\+\/]*$/) === 0) {
+		if (this.string.search(/^[0-9\-\$\:\.\+\/]+$/) === 0) {
 			this.string = "A" + this.string + "A";
 		}
 
@@ -34,7 +34,7 @@ class codabar{
 	}
 
 	valid(){
-		return this.string.search(/^[A-D]?[0-9\-\$\:\.\+\/]*[A-D]$/) !== -1;
+		return this.string.search(/^[A-D][0-9\-\$\:\.\+\/]+[A-D]$/) !== -1;
 	}
 
 	encode(){

--- a/src/barcodes/codabar/index.js
+++ b/src/barcodes/codabar/index.js
@@ -1,0 +1,56 @@
+// Encoding specification:
+// http://www.barcodeisland.com/codabar.phtml
+
+class codabar{
+	constructor(string){
+		this.string = string.toUpperCase();
+
+		if (this.string.search(/^[0-9\-\$\:\.\+\/]*$/) === 0) {
+			this.string = "A" + this.string + "A";
+		}
+
+		this.encodings = {
+			"0": "101010011",
+			"1": "101011001",
+			"2": "101001011",
+			"3": "110010101",
+			"4": "101101001",
+			"5": "110101001",
+			"6": "100101011",
+			"7": "100101101",
+			"8": "100110101",
+			"9": "110100101",
+			"-": "101001101",
+			"$": "101100101",
+			":": "1101011011",
+			"/": "1101101011",
+			".": "1101101101",
+			"+": "101100110011",
+			"A": "1011001001",
+			"B": "1010010011",
+			"C": "1001001011",
+			"D": "1010011001"
+		};
+	}
+
+	valid(){
+		return this.string.search(/^[A-D]?[0-9\-\$\:\.\+\/]*[A-D]$/) !== -1;
+	}
+
+	encode(){
+		var result = [];
+		for(var i = 0; i < this.string.length; i++){
+			result.push(this.encodings[this.string.charAt(i)]);
+			// for all characters except the last, append a narrow-space ("0")
+			if (i !== this.string.length - 1) {
+				result.push("0");
+			}
+		}
+		return {
+			text: this.string.replace(/[A-D]/g, ''),
+			data: result.join('')
+		};
+	}
+}
+
+export {codabar};

--- a/src/barcodes/index.js
+++ b/src/barcodes/index.js
@@ -5,6 +5,7 @@ import {ITF14} from './ITF14/';
 import {ITF} from './ITF/';
 import {MSI, MSI10, MSI11, MSI1010, MSI1110} from './MSI/';
 import {pharmacode} from './pharmacode/';
+import {codabar} from './codabar';
 import {GenericBarcode} from './GenericBarcode/';
 
 export default {
@@ -15,5 +16,6 @@ export default {
 	ITF,
 	MSI, MSI10, MSI11, MSI1010, MSI1110,
 	pharmacode,
+	codabar,
 	GenericBarcode
 };

--- a/test/browser/tests.js
+++ b/test/browser/tests.js
@@ -16,6 +16,9 @@ function createTests(newTest){
   newTest("12345", {format: "pharmacode", width: 1});
   newTest("133742", {format: "CODE128C", width: 1});
   newTest("12345674", {format: "MSI", width: 1});
+  newTest("1234567890", {format: "codabar", width: 1});
+  newTest("A1234567890A", {format: "codabar", width: 1});
+  newTest("C1234567890D", {format: "codabar", width: 1});
   newTest("12345674", {format: "GenericBarcode", width: 1});
   newTest("Such customize!", {
     width: 1,

--- a/test/node/codabar.test.js
+++ b/test/node/codabar.test.js
@@ -1,0 +1,48 @@
+var assert = require('assert');
+var JsBarcode = require('../../bin/JsBarcode.js');
+var Canvas = require("canvas");
+
+describe('Codabar', function() {
+  it('should be able to include the encoder(s)', function () {
+    Codabar = JsBarcode.getModule("codabar");
+  });
+
+  it('should encode a string with start and stop characters', function() {
+    var enc = new Codabar("A12345B");
+    assert.equal("10110010010101011001010100101101100101010101101001011010100101010010011"
+      , enc.encode().data);
+  });
+
+  it('should add start and stop characters to a string without them', function() {
+    var enc = new Codabar("12345");
+    // should encode to "A12345A"
+    assert.equal("10110010010101011001010100101101100101010101101001011010100101011001001"
+      , enc.encode().data);
+  });
+
+  it('should return text string without start/stop characters', function() {
+    var enc = new Codabar("A12345B");
+    assert.equal("12345", enc.encode().text)
+  });
+
+  it('should warn with invalid start/stop characters', function () {
+    var enc = new Codabar("X12345Y");
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with only a start character', function () {
+    var enc = new Codabar("X12345");
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with only a stop character', function () {
+    var enc = new Codabar("12345X");
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with invalid input', function () {
+    var enc = new Codabar("A1234OOPS56A");
+    assert.equal(false, enc.valid());
+  });
+
+});

--- a/test/node/codabar.test.js
+++ b/test/node/codabar.test.js
@@ -55,11 +55,6 @@ describe('Codabar', function() {
     assert.equal(false, enc.valid());
   });
 
-  it('should warn with only start and stop characters', function() {
-    var enc = new Codabar("AA")
-    assert.equal(false, enc.valid());
-  });
-
   it('should warn with an empty string', function() {
     var enc = new Codabar("")
     assert.equal(false, enc.valid());

--- a/test/node/codabar.test.js
+++ b/test/node/codabar.test.js
@@ -35,8 +35,33 @@ describe('Codabar', function() {
     assert.equal(false, enc.valid());
   });
 
+  it('should warn with only an invalid start character', function () {
+    var enc = new Codabar("X12345");
+    assert.equal(false, enc.valid());
+  });
+
   it('should warn with only a stop character', function () {
     var enc = new Codabar("12345A");
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with only an invalid stop character', function () {
+    var enc = new Codabar("12345X");
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with only start and stop characters', function() {
+    var enc = new Codabar("AA")
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with only start and stop characters', function() {
+    var enc = new Codabar("AA")
+    assert.equal(false, enc.valid());
+  });
+
+  it('should warn with an empty string', function() {
+    var enc = new Codabar("")
     assert.equal(false, enc.valid());
   });
 

--- a/test/node/codabar.test.js
+++ b/test/node/codabar.test.js
@@ -31,12 +31,12 @@ describe('Codabar', function() {
   });
 
   it('should warn with only a start character', function () {
-    var enc = new Codabar("X12345");
+    var enc = new Codabar("A12345");
     assert.equal(false, enc.valid());
   });
 
   it('should warn with only a stop character', function () {
-    var enc = new Codabar("12345X");
+    var enc = new Codabar("12345A");
     assert.equal(false, enc.valid());
   });
 


### PR DESCRIPTION
This adds support for the Codabar format (https://en.wikipedia.org/wiki/Codabar, http://www.barcodeisland.com/codabar.phtml). Codabar supports encoding 16 different characters (0-9, -$:/.+), plus four additional start/stop characters (A-D).

The start and stop characters do not appear in the body of a Codabar string, and are stripped from the `text` propery returned by the encoder. If no start/stop characters are passed to the encoder, "A" is assumed for each.