### PR TITLE
Updated TypeScript definitions

### DIFF
--- a/jsbarcode.d.ts
+++ b/jsbarcode.d.ts
@@ -1,7 +1,4 @@
-declare function JsBarcode(element: any): jsbarcode.api;
-declare function JsBarcode(element: any, data: string, options?: jsbarcode.Options): void;
-
-declare namespace jsbarcode {
+declare namespace JsBarcode {
   interface Options {
     width?: number,
     height?: number,
@@ -51,4 +48,8 @@ declare namespace jsbarcode {
   }
 }
 
+declare function JsBarcode(element: any): JsBarcode.api;
+declare function JsBarcode(element: any, data: string, options?: JsBarcode.Options): void;
+
 export = JsBarcode;
+export as namespace JsBarcode;


### PR DESCRIPTION
Hi,

Added a possibility to do this:

```ts
import * as JsBarcode from 'jsbarcode';
const options: JsBarcode.Options = {
  // options here
}
```

Tested with typescript 2.3.1 in WebStorm.