### PR TITLE
Implement UPC-E

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported barcodes:
   * EAN-5
   * EAN-2
   * UPC (A)
+  * UPC (E)
 * [CODE39](https://github.com/lindell/JsBarcode/wiki/CODE39)
 * [ITF-14](https://github.com/lindell/JsBarcode/wiki/ITF-14)
 * [MSI](https://github.com/lindell/JsBarcode/wiki/MSI)

--- a/src/barcodes/EAN_UPC/UPC.js
+++ b/src/barcodes/EAN_UPC/UPC.js
@@ -61,7 +61,7 @@ class UPC extends Barcode{
 		var encoder = new EANencoder();
 		var result = [];
 
-		// Add the first digigt
+		// Add the first digit
 		if(this.displayValue){
 			result.push({
 				data: "00000000",
@@ -117,7 +117,7 @@ class UPC extends Barcode{
 
 // Calulate the checksum digit
 // https://en.wikipedia.org/wiki/International_Article_Number_(EAN)#Calculation_of_checksum_digit
-function checksum(number){
+export function checksum(number){
 	var result = 0;
 
 	var i;

--- a/src/barcodes/EAN_UPC/UPCE.js
+++ b/src/barcodes/EAN_UPC/UPCE.js
@@ -1,0 +1,179 @@
+// Encoding documentation:
+// https://en.wikipedia.org/wiki/Universal_Product_Code#Encoding
+//
+// UPC-E documentation:
+// https://en.wikipedia.org/wiki/Universal_Product_Code#UPC-E
+
+import EANencoder from './ean_encoder.js';
+import Barcode from "../Barcode.js";
+import { checksum } from './UPC.js';
+
+const EXPANSIONS = [
+	"XX00000XXX",
+	"XX10000XXX",
+	"XX20000XXX",
+	"XXX00000XX",
+	"XXXX00000X",
+	"XXXXX00005",
+	"XXXXX00006",
+	"XXXXX00007",
+	"XXXXX00008",
+	"XXXXX00009"
+];
+
+const PARITIES = [
+	["EEEOOO", "OOOEEE"],
+	["EEOEOO", "OOEOEE"],
+	["EEOOEO", "OOEEOE"],
+	["EEOOOE", "OOEEEO"],
+	["EOEEOO", "OEOOEE"],
+	["EOOEEO", "OEEOOE"],
+	["EOOOEE", "OEEEOO"],
+	["EOEOEO", "OEOEOE"],
+	["EOEOOE", "OEOEEO"],
+	["EOOEOE", "OEEOEO"]
+];
+
+class UPCE extends Barcode{
+	constructor(data, options){
+		// Code may be 6 or 8 digits;
+		// A 7 digit code is ambiguous as to whether the extra digit
+		// is a UPC-A check or number system digit.
+		super(data, options);
+		this.isValid = false;
+		if(data.search(/^[0-9]{6}$/) !== -1){
+			this.middleDigits = data;
+			this.upcA = expandToUPCA(data, "0");
+			this.text = options.text ||
+				`${this.upcA[0]}${data}${this.upcA[this.upcA.length - 1]}`;
+			this.isValid = true;
+		}
+		else if(data.search(/^[01][0-9]{7}$/) !== -1){
+			this.middleDigits = data.substring(1, data.length - 1);
+			this.upcA = expandToUPCA(this.middleDigits, data[0]);
+
+			if(this.upcA[this.upcA.length - 1] === data[data.length - 1]){
+				this.isValid = true;
+			}
+			else{
+				// checksum mismatch
+				return;
+			}
+		}
+		else{
+			return;
+		}
+
+		this.displayValue = options.displayValue;
+
+		// Make sure the font is not bigger than the space between the guard bars
+		if(options.fontSize > options.width * 10){
+			this.fontSize = options.width * 10;
+		}
+		else{
+			this.fontSize = options.fontSize;
+		}
+
+		// Make the guard bars go down half the way of the text
+		this.guardHeight = options.height + this.fontSize / 2 + options.textMargin;
+	}
+
+	valid(){
+		return this.isValid;
+	}
+
+	encode(){
+		if(this.options.flat){
+			return this.flatEncoding();
+		}
+		else{
+			return this.guardedEncoding();
+		}
+	}
+
+	flatEncoding(){
+		var encoder = new EANencoder();
+		var result = "";
+
+		result += "101";
+		result += this.encodeMiddleDigits(encoder);
+		result += "010101";
+
+		return {
+			data: result,
+			text: this.text
+		};
+	}
+
+	guardedEncoding(){
+		var encoder = new EANencoder();
+		var result = [];
+
+		// Add the UPC-A number system digit beneath the quiet zone
+		if(this.displayValue){
+			result.push({
+				data: "00000000",
+				text: this.text[0],
+				options: {textAlign: "left", fontSize: this.fontSize}
+			});
+		}
+
+		// Add the guard bars
+		result.push({
+			data: "101",
+			options: {height: this.guardHeight}
+		});
+
+		// Add the 6 UPC-E digits
+		result.push({
+			data: this.encodeMiddleDigits(encoder),
+			text: this.text.substring(1, 7),
+			options: {fontSize: this.fontSize}
+		});
+
+		// Add the end bits
+		result.push({
+			data: "010101",
+			options: {height: this.guardHeight}
+		});
+
+		// Add the UPC-A check digit beneath the quiet zone
+		if(this.displayValue){
+			result.push({
+				data: "00000000",
+				text: this.text[7],
+				options: {textAlign: "right", fontSize: this.fontSize}
+			});
+		}
+
+		return result;
+	}
+
+	encodeMiddleDigits(encoder) {
+		const numberSystem = this.upcA[0];
+		const checkDigit = this.upcA[this.upcA.length - 1];
+		const parity = PARITIES[parseInt(checkDigit)][parseInt(numberSystem)];
+		return encoder.encode(this.middleDigits, parity);
+	}
+}
+
+function expandToUPCA(middleDigits, numberSystem) {
+	const lastUpcE = parseInt(middleDigits[middleDigits.length - 1]);
+	const expansion = EXPANSIONS[lastUpcE];
+
+	let result = "";
+	let digitIndex = 0;
+	for(let i = 0; i < expansion.length; i++) {
+		let c = expansion[i];
+		if (c === 'X') {
+			result += middleDigits[digitIndex++];
+		} else {
+			result += c;
+		}
+	}
+
+	result = `${numberSystem}${result}`;
+	return `${result}${checksum(result)}`;
+}
+
+export default UPCE;

--- a/src/barcodes/EAN_UPC/ean_encoder.js
+++ b/src/barcodes/EAN_UPC/ean_encoder.js
@@ -5,47 +5,77 @@ class EANencoder{
 		this.endBin = "101";
 		this.middleBin = "01010";
 
-		// The L (left) type of encoding
-		this.Lbinary = [
-			"0001101",
-			"0011001",
-			"0010011",
-			"0111101",
-			"0100011",
-			"0110001",
-			"0101111",
-			"0111011",
-			"0110111",
-			"0001011"
-		];
+		this.binaries = {
+			// The L (left) type of encoding
+			"L": [
+				"0001101",
+				"0011001",
+				"0010011",
+				"0111101",
+				"0100011",
+				"0110001",
+				"0101111",
+				"0111011",
+				"0110111",
+				"0001011"
+			],
 
-		// The G type of encoding
-		this.Gbinary = [
-			"0100111",
-			"0110011",
-			"0011011",
-			"0100001",
-			"0011101",
-			"0111001",
-			"0000101",
-			"0010001",
-			"0001001",
-			"0010111"
-		];
+			// The G type of encoding
+			"G": [
+				"0100111",
+				"0110011",
+				"0011011",
+				"0100001",
+				"0011101",
+				"0111001",
+				"0000101",
+				"0010001",
+				"0001001",
+				"0010111"
+			],
 
-		// The R (right) type of encoding
-		this.Rbinary = [
-			"1110010",
-			"1100110",
-			"1101100",
-			"1000010",
-			"1011100",
-			"1001110",
-			"1010000",
-			"1000100",
-			"1001000",
-			"1110100"
-		];
+			// The R (right) type of encoding
+			"R": [
+				"1110010",
+				"1100110",
+				"1101100",
+				"1000010",
+				"1011100",
+				"1001110",
+				"1010000",
+				"1000100",
+				"1001000",
+				"1110100"
+			],
+
+			// The O (odd) encoding for UPC-E
+			"O": [
+				"0001101",
+				"0011001",
+				"0010011",
+				"0111101",
+				"0100011",
+				"0110001",
+				"0101111",
+				"0111011",
+				"0110111",
+				"0001011"
+			],
+
+			// The E (even) encoding for UPC-E
+			"E": [
+				"0100111",
+				"0110011",
+				"0011011",
+				"0100001",
+				"0011101",
+				"0111001",
+				"0000101",
+				"0010001",
+				"0001001",
+				"0010111"
+			]
+		};
 	}
 
 	// Convert a numberarray to the representing
@@ -59,14 +89,9 @@ class EANencoder{
 		// Loop all the numbers
 		for(var i = 0; i < number.length; i++){
 			// Using the L, G or R encoding and add it to the returning variable
-			if(structure[i] == "L"){
-				result += this.Lbinary[number[i]];
-			}
-			else if(structure[i] == "G"){
-				result += this.Gbinary[number[i]];
-			}
-			else if(structure[i] == "R"){
-				result += this.Rbinary[number[i]];
+			let binary = this.binaries[structure[i]];
+			if (binary) {
+				result += binary[number[i]];
 			}
 
 			// Add separator in between encodings

--- a/src/barcodes/EAN_UPC/index.js
+++ b/src/barcodes/EAN_UPC/index.js
@@ -3,5 +3,6 @@ import EAN8 from './EAN8.js';
 import EAN5 from './EAN5.js';
 import EAN2 from './EAN2.js';
 import UPC from './UPC.js';
+import UPCE from './UPCE.js';
 
-export {EAN13, EAN8, EAN5, EAN2, UPC};
+export {EAN13, EAN8, EAN5, EAN2, UPC, UPCE};

--- a/src/barcodes/index.js
+++ b/src/barcodes/index.js
@@ -1,6 +1,6 @@
 import {CODE39} from './CODE39/';
 import {CODE128, CODE128A, CODE128B, CODE128C} from './CODE128/';
-import {EAN13, EAN8, EAN5, EAN2, UPC} from './EAN_UPC/';
+import {EAN13, EAN8, EAN5, EAN2, UPC, UPCE} from './EAN_UPC/';
 import {ITF14} from './ITF14/';
 import {ITF} from './ITF/';
 import {MSI, MSI10, MSI11, MSI1010, MSI1110} from './MSI/';
@@ -11,7 +11,7 @@ import {GenericBarcode} from './GenericBarcode/';
 export default {
 	CODE39,
 	CODE128, CODE128A, CODE128B, CODE128C,
-	EAN13, EAN8, EAN5, EAN2, UPC,
+	EAN13, EAN8, EAN5, EAN2, UPC, UPCE,
 	ITF14,
 	ITF,
 	MSI, MSI10, MSI11, MSI1010, MSI1110,

--- a/test/browser/tests.js
+++ b/test/browser/tests.js
@@ -9,6 +9,7 @@ function createTests(newTest){
   newTest("52", {format: "EAN2", width: 1});
   newTest("423514346455", {format: "UPC", width: 2, textMargin: 0});
   newTest("423514346455", {format: "UPC", width: 2, textMargin: 0, flat: true});
+  newTest("01245714", {format: "UPCE", width: 2, textMargin: 0});
   newTest("5901234123457", {format: "EAN13", fontSize: 40, textMargin: 0, lastChar: ">"});
   newTest("590123412345", {format: "EAN13", width: 2, fontSize: 16});
   newTest("590123412345", {format: "EAN13", width: 3});

--- a/test/node/EAN-UPC.test.js
+++ b/test/node/EAN-UPC.test.js
@@ -6,7 +6,7 @@ var clone = help.clone;
 
 var options = {height: 100, displayValue: true, fontSize: 20, textMargin: 2, width: 2};
 
-describe('UPC', function() {
+describe('UPC-A', function() {
   it('should be able to include the encoder(s)', function () {
     UPC = JsBarcode.getModule("UPC");
   });
@@ -37,6 +37,39 @@ describe('UPC', function() {
     assert.equal("10100110010010011011110101000110110001010111101010100010010010001110100111010011101001110100101"
       , enc.encode().data);
     assert.equal("123456789999", enc.encode().text);
+  });
+});
+
+const UPCE_BINARY = "101011001100100110011101011100101110110011001010101";
+describe('UPC-E', function() {
+  it('should be able to include the encoder(s)', function () {
+    UPCE = JsBarcode.getModule("UPCE");
+  });
+
+  it('should be able to encode 8-digit codes', function () {
+    var enc = new UPCE("01245714", clone(options));
+    assert.equal(UPCE_BINARY, help.fixBin(enc.encode()));
+  });
+
+  it('should be able to encode 6-digit codes by assuming a 0 number system', function () {
+    var enc = new UPCE("124571", clone(options));
+    assert.equal(UPCE_BINARY, help.fixBin(enc.encode()));
+  });
+
+  it('should warn with invalid text', function () {
+    var enc = new UPCE("01245715", clone(options));
+    assert.equal(false, enc.valid());
+  });
+
+  it('should work with text option', function () {
+    var enc = new UPCE("124571", help.merge(options, {text: "SOMETEXT"}));
+    assert.equal("SOMETEXT", help.fixText(enc.encode()));
+  });
+
+  it('should work with flat option', function () {
+    var enc = new UPCE("01245714", help.merge(options, {flat: true}));
+    assert.equal(UPCE_BINARY, enc.encode().data);
+    assert.equal("01245714", enc.encode().text);
   });
 });
 


### PR DESCRIPTION
Closes #126

Implements a `UPCE` formatter, which accepts 6
and 8 digit codes as input.

6-digits:

- assumes "0" as UPC-A number system, and
  automatically computes UPC-A check digit

8-digits:

- assumes number system (0 or 1) is specified
- validates that provided check digit matches