### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ JsBarcode is shared under the [MIT license](https://github.com/lindell/JsBarcode
 
 
 
-[1]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/JsBarcode.all.min.js "jsdelivr all barcodes"
-[2]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.code128.min.js "jsdelivr code128"
-[3]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.code39.min.js "jsdelivr code39"
-[4]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.ean-upc.min.js "jsdelivr ean/upc"
-[5]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.itf-14.min.js "jsdelivr itf-14"
-[6]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.itf.min.js "jsdelivr itf"
-[7]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.msi.min.js "jsdelivr msi"
-[8]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.pharmacode.min.js "jsdelivr pharmacode"
-[9]: https://cdn.jsdelivr.net/jsbarcode/3.5.8/barcodes/JsBarcode.codabar.min.js "jsdelivr codabar"
+[1]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/JsBarcode.all.min.js "jsdelivr all barcodes"
+[2]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.code128.min.js "jsdelivr code128"
+[3]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.code39.min.js "jsdelivr code39"
+[4]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.ean-upc.min.js "jsdelivr ean/upc"
+[5]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.itf-14.min.js "jsdelivr itf-14"
+[6]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.itf.min.js "jsdelivr itf"
+[7]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.msi.min.js "jsdelivr msi"
+[8]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.pharmacode.min.js "jsdelivr pharmacode"
+[9]: https://cdn.jsdelivr.net/npm/jsbarcode@3.8.0/dist/barcodes/JsBarcode.codabar.min.js "jsdelivr codabar"


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jsbarcode.

Feel free to ping me if you have any questions regarding this change.