### PR TITLE
fix: use `babel-preset-es2015-ie` to adapt ios8.x、Android4.x..

### DIFF
--- a/automation/building.js
+++ b/automation/building.js
@@ -24,7 +24,7 @@ gulp.task("babel", function () {
 function babelFunc(){
 	return gulp.src("src/**/*")
 		.pipe(babel({
-			presets: ['es2015', 'stage-3']
+			presets: ['es2015-ie', 'stage-3']
 		}))
 		.pipe(gulp.dest("bin/"));
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es2015-ie": "^6.7.0",
     "babel-preset-stage-3": "6.24.1",
     "blanket": "^1.2.3",
     "canvas": "^1.6.5",


### PR DESCRIPTION
throung our monitoring,it doesn't work in ios8.x、Android4.x and the low version of web browser engines(eg:UC).

BABEL transforming ES6 classes to ES5 syntax has compatibility issues.

Links: [same problem](https://github.com/stripe/react-stripe-elements/issues/140)、  [looseMode](http://2ality.com/2015/12/babel6-loose-mode.html?utm_source=tuicool&utm_medium=referral)

It's a better way to use `babel-preset-es2015-ie`.

differences between babel-preset-es2015-ie and babel-preset-es2015
```
 [
  [require('babel-plugin-transform-es2015-classes'), {loose: true}],
  require('babel-plugin-transform-proto-to-assign'),
]
```
