### PR TITLE
Change default height from 100 to 1

### DIFF
--- a/src/options/defaults.js
+++ b/src/options/defaults.js
@@ -1,6 +1,6 @@
 var defaults = {
 	width: 2,
-	height: 100,
+	height: 1,
 	format: "auto",
 	displayValue: true,
 	fontOptions: "",


### PR DESCRIPTION
The default height of 100 causes unwanted results with the "blank" space between EAN13 and EAN5 add-on codes in PDF rendering app wkhtmltopdf (which uses the Webkit browser). This problem goes away when the default is changed to 1.