### PR TITLE
Non flat EAN8

### DIFF
--- a/jsbarcode.d.ts
+++ b/jsbarcode.d.ts
@@ -25,6 +25,10 @@ declare namespace JsBarcode {
     ean128?: boolean;
   }
 
+  interface Ean8Options extends BaseOptions {
+    flat?: boolean;
+  }
+
   interface Ean13Options extends BaseOptions {
     flat?: boolean;
     lastChar?: string;
@@ -43,7 +47,7 @@ declare namespace JsBarcode {
     CODE128B(value: string, options?: Code128Options): api;
     CODE128C(value: string, options?: Code128Options): api;
     EAN13(value: string, options?: Ean13Options): api;
-    EAN8(value: string, options?: BaseOptions): api;
+    EAN8(value: string, options?: Ean8Options): api;
     EAN5(value: string, options?: BaseOptions): api;
     EAN2(value: string, options?: BaseOptions): api;
     UPC(value: string, options?: BaseOptions): api;

--- a/src/barcodes/EAN_UPC/EAN.js
+++ b/src/barcodes/EAN_UPC/EAN.js
@@ -1,0 +1,72 @@
+import { SIDE_BIN, MIDDLE_BIN } from './constants';
+import encode from './encoder';
+import Barcode from '../Barcode';
+
+// Base class for EAN8 & EAN13
+class EAN extends Barcode {
+
+	constructor(data, options) {
+		super(data, options);
+
+		// Make sure the font is not bigger than the space between the guard bars
+		this.fontSize = !options.flat && options.fontSize > options.width * 10
+			? options.width * 10
+			: options.fontSize;
+
+		// Make the guard bars go down half the way of the text
+		this.guardHeight = options.height + this.fontSize / 2 + options.textMargin;
+	}
+
+	encode() {
+		return this.options.flat
+			? this.encodeFlat()
+			: this.encodeGuarded();
+	}
+
+	leftText(from, to) {
+		return this.text.substr(from, to);
+	}
+
+	leftEncode(data, structure) {
+		return encode(data, structure);
+	}
+
+	rightText(from, to) {
+		return this.text.substr(from, to);
+	}
+
+	rightEncode(data, structure) {
+		return encode(data, structure);
+	}
+
+	encodeGuarded() {
+		const textOptions = { fontSize: this.fontSize };
+		const guardOptions = { height: this.guardHeight };
+
+		return [
+			{ data: SIDE_BIN, options: guardOptions },
+			{ data: this.leftEncode(), text: this.leftText(), options: textOptions },
+			{ data: MIDDLE_BIN, options: guardOptions },
+			{ data: this.rightEncode(), text: this.rightText(), options: textOptions },
+			{ data: SIDE_BIN, options: guardOptions },
+		];
+	}
+
+	encodeFlat() {
+		const data = [
+			SIDE_BIN,
+			this.leftEncode(),
+			MIDDLE_BIN,
+			this.rightEncode(),
+			SIDE_BIN
+		];
+
+		return {
+			data: data.join(''),
+			text: this.text
+		};
+	}
+
+}
+
+export default EAN;

--- a/src/barcodes/EAN_UPC/EAN8.js
+++ b/src/barcodes/EAN_UPC/EAN8.js
@@ -1,9 +1,7 @@
 // Encoding documentation:
 // http://www.barcodeisland.com/ean8.phtml
 
-import { SIDE_BIN, MIDDLE_BIN } from './constants';
-import encode from './encoder';
-import Barcode from "../Barcode";
+import EAN from './EAN';
 
 // Calculate the checksum digit
 const checksum = (number) => {
@@ -18,11 +16,11 @@ const checksum = (number) => {
 	return (10 - (res % 10)) % 10;
 };
 
-class EAN8 extends Barcode {
+class EAN8 extends EAN {
 
 	constructor(data, options) {
 		// Add checksum if it does not exist
-		if(data.search(/^[0-9]{7}$/) !== -1){
+		if (data.search(/^[0-9]{7}$/) !== -1) {
 			data += checksum(data);
 		}
 
@@ -36,27 +34,22 @@ class EAN8 extends Barcode {
 		);
 	}
 
-	get leftData() {
-		return this.data.substr(0, 4);
+	leftText() {
+		return super.leftText(0, 4);
 	}
 
-	get rightData() {
-		return this.data.substr(4, 4);
+	leftEncode() {
+		const data = this.data.substr(0, 4);
+		return super.leftEncode(data, 'LLLL');
 	}
 
-	encode() {
-		const data = [
-			SIDE_BIN,
-			encode(this.leftData, 'LLLL'),
-			MIDDLE_BIN,
-			encode(this.rightData, 'RRRR'),
-			SIDE_BIN,
-		];
+	rightText() {
+		return super.rightText(4, 4);
+	}
 
-		return {
-			data: data.join(''),
-			text: this.text
-		};
+	rightEncode() {
+		const data = this.data.substr(4, 4);
+		return super.rightEncode(data, 'RRRR');
 	}
 
 }

--- a/test/node/EAN-UPC.test.js
+++ b/test/node/EAN-UPC.test.js
@@ -122,16 +122,25 @@ describe('EAN-8', function() {
     var enc = new EAN8("96385074", {});
     assert.equal(true, enc.valid());
     assert.equal("1010001011010111101111010110111010101001110111001010001001011100101"
+      , help.fixBin(enc.encode()));
+    assert.equal("96385074", help.fixText(enc.encode()));
+  });
+
+  it('should be able to encode normal text with flat option', function () {
+    var enc = new EAN8("96385074", help.merge(options, {flat: true}));
+    assert.equal(true, enc.valid());
+    assert.equal("1010001011010111101111010110111010101001110111001010001001011100101"
       , enc.encode().data);
+    assert.equal("96385074", help.fixText(enc.encode()));
   });
 
   it('should auto include the checksum if missing', function () {
     var enc = new EAN8("9638507", {});
 
     assert.equal(true, enc.valid());
-    assert.equal("96385074", enc.encode().text);
+    assert.equal("96385074", help.fixText(enc.encode()));
     assert.equal("1010001011010111101111010110111010101001110111001010001001011100101"
-      , enc.encode().data);
+      , help.fixBin(enc.encode()));
   });
 
   it('should warn with invalid text', function () {
@@ -143,7 +152,7 @@ describe('EAN-8', function() {
   });
 
   it('should work with text option', function () {
-    var enc = new EAN8("96385074", help.merge(options, {text: "THISISTEXT"}));
+    var enc = new EAN8("96385074", help.merge(options, {text: "THISISTEXT", flat: true}));
     assert.equal("THISISTEXT", help.fixText(enc.encode()));
   });
 });


### PR DESCRIPTION
I've created a base class for EAN8 and EAN13, that united base logic.
Please note, this pr has a breaking change - EAN8 is not flat by default. I suppose we can publish it as a part of 4.0.0 version.

@lindell what do you think?