### PR TITLE
Fixes typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported barcodes:
 Examples for browsers:
 ----
 
-#### First create an canvas (or image)
+#### First create a canvas (or image)
 ````html
 <svg id="barcode"></svg>
 <!-- or -->


### PR DESCRIPTION
A very quick PR to correct a typo:

_an canvas_ ➡️ _a canvas_
