### PR TITLE
updated BaseOptions.format with explicit format types

### DIFF
--- a/jsbarcode.d.ts
+++ b/jsbarcode.d.ts
@@ -1,8 +1,29 @@
 declare namespace JsBarcode {
+  type Format =
+    | "CODE39"
+    | "CODE128"
+    | "CODE128A"
+    | "CODE128B"
+    | "CODE128C"
+    | "EAN13"
+    | "EAN8"
+    | "EAN5"
+    | "EAN2"
+    | "UPC"
+    | "ITF14"
+    | "ITF"
+    | "MSI"
+    | "MSI10"
+    | "MSI11"
+    | "MSI1010"
+    | "MSI1110"
+    | "pharmacode"
+    | "codabar";
+
   interface BaseOptions {
     width?: number;
     height?: number;
-    format?: string;
+    format?: Format;
     displayValue?: boolean;
     fontOptions?: string;
     font?: string;
@@ -64,7 +85,11 @@ declare namespace JsBarcode {
 }
 
 declare function JsBarcode(element: any): JsBarcode.api;
-declare function JsBarcode(element: any, data: string, options?: JsBarcode.Options): void;
+declare function JsBarcode(
+  element: any,
+  data: string,
+  options?: JsBarcode.Options
+): void;
 
 export = JsBarcode;
 export as namespace JsBarcode;


### PR DESCRIPTION
This PR changes the Typscript typings for `BaseOptions.format` from `string`  to `type Format = 'CODE39 | 'CODE128' | ...`.  This will help us spell and case the formats correctly and give type-hinting from the IDE.