### PR TITLE
Update JsBarcode.all.js

### DIFF
--- a/dist/JsBarcode.all.js
+++ b/dist/JsBarcode.all.js
@@ -1568,7 +1568,7 @@ API.prototype.init = function () {
 
 		this._errorHandler.wrapBarcodeCall(function () {
 			var text = options.value;
-			var Encoder = _barcodes2.default[options.format.toUpperCase()];
+			var Encoder = _barcodes2.default[options.format];
 			var encoded = encode(text, Encoder, options);
 
 			render(renderProperty, encoded, options);


### PR DESCRIPTION
propose remove .toUpperCase() or insert in upper value every format of barcode