### PR TITLE
Fix instanceof checks for a cross-realm scenario

### DIFF
--- a/src/help/getRenderProperties.js
+++ b/src/help/getRenderProperties.js
@@ -61,7 +61,7 @@ function newCanvasRenderProperties(imgElement){
 
 function elementInstanceRenderProperties(element){
 	const globalThis = typeof window !== 'undefined' ? window : global;
-	const ownerDocument = element.ownerDocument || globalThis.document;
+	const ownerDocument = element && element.ownerDocument || globalThis.document;
 	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || globalThis;
 
 	// If element, render on canvas and set the uri as src

--- a/src/help/getRenderProperties.js
+++ b/src/help/getRenderProperties.js
@@ -1,7 +1,3 @@
-/* global HTMLImageElement */
-/* global HTMLCanvasElement */
-/* global SVGElement */
-
 import getOptionsFromElement from "./getOptionsFromElement.js";
 import renderers from "../renderers";
 
@@ -18,7 +14,7 @@ import {InvalidElementException} from "../exceptions/exceptions.js";
 //   options (optional): Options that can be defined in the element
 // }
 
-function getRenderProperties(element){
+function getRenderProperties(element) {
 	// If the element is a string, query select call again
 	if(typeof element === "string"){
 		return querySelectedRenderProperties(element);
@@ -31,14 +27,50 @@ function getRenderProperties(element){
 		}
 		return returnArray;
 	}
+	// If an element is a single instance
+	else{
+		return elementInstanceRenderProperties(element);
+	}
+}
+
+function querySelectedRenderProperties(string){
+	var selector = document.querySelectorAll(string);
+	if(selector.length === 0){
+		return undefined;
+	}
+	else{
+		let returnArray = [];
+		for(let i = 0; i < selector.length; i++){
+			returnArray.push(getRenderProperties(selector[i]));
+		}
+		return returnArray;
+	}
+}
+
+function newCanvasRenderProperties(imgElement){
+	var canvas = document.createElement('canvas');
+	return {
+		element: canvas,
+		options: getOptionsFromElement(imgElement),
+		renderer: renderers.CanvasRenderer,
+		afterRender: function(){
+			imgElement.setAttribute("src", canvas.toDataURL());
+		}
+	};
+}
+
+function elementInstanceRenderProperties(element){
+	const ownerDocument = element.ownerDocument || document;
+	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || window;
+
 	// If element, render on canvas and set the uri as src
-	else if(typeof HTMLCanvasElement !== 'undefined' && element instanceof HTMLImageElement){
+	if(typeof HTMLCanvasElement !== 'undefined' && element instanceof ownerWindow.HTMLImageElement){
 		return newCanvasRenderProperties(element);
 	}
 	// If SVG
 	else if(
 		(element && element.nodeName === 'svg') ||
-		(typeof SVGElement !== 'undefined' && element instanceof SVGElement)
+		(typeof SVGElement !== 'undefined' && element instanceof ownerWindow.SVGElement)
 	){
 		return {
 			element: element,
@@ -47,7 +79,7 @@ function getRenderProperties(element){
 		};
 	}
 	// If canvas (in browser)
-	else if(typeof HTMLCanvasElement !== 'undefined' && element instanceof HTMLCanvasElement){
+	else if(typeof HTMLCanvasElement !== 'undefined' && element instanceof ownerWindow.HTMLCanvasElement){
 		return {
 			element: element,
 			options: getOptionsFromElement(element),
@@ -70,33 +102,6 @@ function getRenderProperties(element){
 	else{
 		throw new InvalidElementException();
 	}
-}
-
-function querySelectedRenderProperties(string){
-	var selector = document.querySelectorAll(string);
-	if(selector.length === 0){
-		return undefined;
-	}
-	else{
-		let returnArray = [];
-		for(let i = 0; i < selector.length; i++){
-			returnArray.push(getRenderProperties(selector[i]));
-		}
-		return returnArray;
-	}
-}
-
-
-function newCanvasRenderProperties(imgElement){
-	var canvas = document.createElement('canvas');
-	return {
-		element: canvas,
-		options: getOptionsFromElement(imgElement),
-		renderer: renderers.CanvasRenderer,
-		afterRender: function(){
-			imgElement.setAttribute("src", canvas.toDataURL());
-		}
-	};
 }
 
 export default getRenderProperties;

--- a/src/help/getRenderProperties.js
+++ b/src/help/getRenderProperties.js
@@ -60,8 +60,9 @@ function newCanvasRenderProperties(imgElement){
 }
 
 function elementInstanceRenderProperties(element){
-	const ownerDocument = element.ownerDocument || document;
-	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || window;
+	const global = typeof window !== 'undefined' ? window : global;
+	const ownerDocument = element.ownerDocument || global.document;
+	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || global.window;
 
 	// If element, render on canvas and set the uri as src
 	if(typeof HTMLCanvasElement !== 'undefined' && element instanceof ownerWindow.HTMLImageElement){

--- a/src/help/getRenderProperties.js
+++ b/src/help/getRenderProperties.js
@@ -60,9 +60,9 @@ function newCanvasRenderProperties(imgElement){
 }
 
 function elementInstanceRenderProperties(element){
-	const global = typeof window !== 'undefined' ? window : global;
-	const ownerDocument = element.ownerDocument || global.document;
-	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || global.window;
+	const globalThis = typeof window !== 'undefined' ? window : global;
+	const ownerDocument = element.ownerDocument || globalThis.document;
+	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || globalThis;
 
 	// If element, render on canvas and set the uri as src
 	if(typeof HTMLCanvasElement !== 'undefined' && element instanceof ownerWindow.HTMLImageElement){

--- a/src/help/getRenderProperties.js
+++ b/src/help/getRenderProperties.js
@@ -62,7 +62,7 @@ function newCanvasRenderProperties(imgElement){
 function elementInstanceRenderProperties(element){
 	const globalThis = typeof window !== 'undefined' ? window : global;
 	const ownerDocument = element && element.ownerDocument || globalThis.document;
-	const ownerWindow = ownerDocument.defaultView || ownerDocument.parentWindow || globalThis;
+	const ownerWindow = ownerDocument && (ownerDocument.defaultView || ownerDocument.parentWindow) || globalThis;
 
 	// If element, render on canvas and set the uri as src
 	if(typeof HTMLCanvasElement !== 'undefined' && element instanceof ownerWindow.HTMLImageElement){


### PR DESCRIPTION
Hi.

The current `getRenderProperties()` implementation is nice, but it fails when a JS-code calling `JsBarcode()`  and a target DOM element belong to different realms (= windows). 
Yep, it is the real case in our internal codebase. :)

I have improved the implementation slightly by using explicit references to the appropriate classes instead of implicit global references. 

Links with info:
1. [Determining with absolute accuracy whether or not a JavaScript object is an array](http://web.mit.edu/jwalden/www/isArray.html). (In case of the cross-realm `instanceof` problem is unclear to you.)
2. [MDN: Node.ownerDocument](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument).
3. [MDN: Document.defaultView](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView).
4. [SO: How can I get the window object that an HTML node belongs to using JavaScript?](https://stackoverflow.com/questions/223991/how-can-i-get-the-window-object-that-an-html-node-belongs-to-using-javascript).
