### PR TITLE
Add support for using JsBarcode in implementations that don't implement measureText

### DIFF
--- a/src/renderers/shared.js
+++ b/src/renderers/shared.js
@@ -80,8 +80,14 @@ function messureText(string, options, context){
 	ctx.font = options.fontOptions + " " + options.fontSize + "px " + options.font;
 
 	// Calculate the width of the encoding
-	var size = ctx.measureText(string).width;
-
+	var measureTextResult = ctx.measureText(string);
+	if (!measureTextResult) {
+		// Some implementations don't implement measureText and return undefined.
+		// If the text cannot be measured we will return 0.
+		// This will make some barcode with big text render incorrectly
+		return 0;
+	}
+	var size = measureTextResult.width;
 	return size;
 }
 


### PR DESCRIPTION
We use an HTML to PDF converter which returns undefined for ctx.measureText(). In this PR we return 0 instead of crashing the JavaScript code.

I was not able to run `node_modules/gulp/bin/gulp.js lint` as it complains about ' Unexpected top-level property "predef".' in .eslintrc.

If I need to do something else, please let me know 