### PR TITLE
Support style CSP nonce for SVG renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ For information about how to use the options, see [the wiki page](https://github
 | [`marginLeft`](https://github.com/lindell/JsBarcode/wiki/Options#margins) | `undefined` | `Number` |
 | [`marginRight`](https://github.com/lindell/JsBarcode/wiki/Options#margins) | `undefined` | `Number` |
 | [`valid`](https://github.com/lindell/JsBarcode/wiki/Options#valid) | `function(valid){}` | `Function` |
+| [`nonce`](https://github.com/lindell/JsBarcode/wiki/Options#nonce) | `undefined` | `String` |
 
 Contributions and feedback:
 ----

--- a/example/cspNonce.html
+++ b/example/cspNonce.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'self';script-src 'nonce-nonce_placeholder';style-src 'nonce-nonce_placeholder'">
+	<meta property="csp-nonce" nonce="nonce_placeholder" />
+	<title></title>
+	<script src="../dist/JsBarcode.all.js" nonce="nonce_placeholder"></script>
+	<script nonce="nonce_placeholder">
+		Number.prototype.zeroPadding = function(){
+			var ret = "" + this.valueOf();
+			return ret.length == 1 ? "0" + ret : ret;
+		};
+	</script>
+</head>
+<body>
+	<div>
+		<svg id="barcode1"/>
+		<script nonce="nonce_placeholder">JsBarcode("#barcode1", "Hi!");</script>
+	</div>
+
+	<div>
+		<svg id="barcode2"/>
+		<script nonce="nonce_placeholder">
+			JsBarcode("#barcode2", "9780199532179", {
+			  format:"EAN13",
+			  displayValue:true,
+			  fontSize:24,
+			  lineColor: "#0cc"
+			});
+		</script>
+	</div>
+
+	<div>
+		<svg id="barcode3"/>
+		<script nonce="nonce_placeholder">JsBarcode("#barcode3", "9780199532179", {
+			format:"EAN13",
+			displayValue:true,
+			fontSize:20
+		});</script>
+	</div>
+
+	<div>
+		<svg id="barcode4"/>
+		<script nonce="nonce_placeholder">
+			var repeat4 = function(){
+				var date = new Date();
+				JsBarcode("#barcode4",
+						date.getHours().zeroPadding() + ":" +
+						date.getMinutes().zeroPadding() + ":" +
+						date.getSeconds().zeroPadding(),
+					{displayValue: true});
+			};
+			setInterval(repeat4,1000);
+			repeat4();
+		</script>
+	</div>
+
+	<div>
+		<svg id="barcode5"/>
+		<script nonce="nonce_placeholder">
+			var repeat5 = function(){
+				JsBarcode("#barcode5", Math.floor(1000000+Math.random()*9000000)+"",{displayValue:true,fontSize:20});
+			};
+			setInterval(repeat5,500);
+			repeat5();
+		</script>
+	</div>
+</body>
+</html>

--- a/jsbarcode.d.ts
+++ b/jsbarcode.d.ts
@@ -38,7 +38,11 @@ declare namespace JsBarcode {
     lastChar?: string;
   }
 
-  type Options = BaseOptions | Code128Options | Ean13Options | NodeOptions;
+  interface BrowserOptions extends BaseOptions {
+    nonce?: string;
+  }
+
+  type Options = BaseOptions | Code128Options | Ean13Options | NodeOptions | BrowserOptions;
 
   interface api {
     options(options: Options): api;

--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -3,15 +3,72 @@ import {calculateEncodingAttributes, getTotalWidthOfEncodings, getMaximumHeightO
 
 var svgns = "http://www.w3.org/2000/svg";
 
+var idSeq = 1;
+
 class SVGRenderer{
 	constructor(svg, encodings, options){
 		this.svg = svg;
 		this.encodings = encodings;
 		this.options = options;
 		this.document = options.xmlDocument || document;
+
+		if (!options.xmlDocument) {
+			this.createStylesheet();
+		}
+	}
+
+	createStylesheet() {
+		if (!this.svg.id) {
+			this.svg.id = 'jsbc' + idSeq++;
+		}
+		var styleId = this.svg.id + '_jsbcstyle';
+		if (!document.getElementById(styleId)) {
+			var head = document.head || document.getElementsByTagName('head')[0];
+			var style = document.createElement('style');
+			style.id = styleId;
+			var nonce = this.options.nonce;
+			if (!nonce) {
+				const cspNonce = document.querySelector('meta[property=csp-nonce]');
+				if (cspNonce) {
+					nonce = cspNonce.nonce;
+				}
+			}
+			if (nonce) {
+				style.setAttribute('nonce', nonce);
+			}
+			style.setAttribute('type', 'text/css');
+			style.textContent = `
+				#${this.svg.id} {
+					transform: translate(0,0);
+				}
+			`;
+			if (this.options.background) {
+				style.textContent += `
+				#${this.svg.id} > rect {
+					fill: ${this.options.background};
+				}
+				`;
+			}
+			if (this.options.lineColor) {
+				style.textContent += `
+				#${this.svg.id} g {
+					fill: ${this.options.lineColor};
+				}
+				`;
+			}
+			if (this.options.fontOptions || this.options.fontSize || this.options.font) {
+				style.textContent += `
+				#${this.svg.id} text {
+					font: ${this.options.fontOptions} ${this.options.fontSize}px ${this.options.font};
+				}
+				`;
+			}
+			head.appendChild(style);
+		}
 	}
 
 	render(){
+
 		var currentX = this.options.marginLeft;
 
 		this.prepareSVG();
@@ -44,9 +101,12 @@ class SVGRenderer{
 		this.setSvgAttributes(width, maxHeight);
 
 		if(this.options.background){
-			this.drawRect(0, 0, width, maxHeight, this.svg).setAttribute(
-				"style", "fill:" + this.options.background + ";"
-			);
+			var rect = this.drawRect(0, 0, width, maxHeight, this.svg);
+			if (this.options.xmlDocument) {
+				rect.setAttribute(
+					"style", "fill:" + this.options.background + ";"
+				);
+			}
 		}
 	}
 
@@ -89,9 +149,11 @@ class SVGRenderer{
 		if(options.displayValue){
 			var x, y;
 
-			textElem.setAttribute("style",
-				"font:" + options.fontOptions + " " + options.fontSize + "px " + options.font
-			);
+			if (options.xmlDocument) {
+				textElem.setAttribute("style",
+					"font:" + options.fontOptions + " " + options.fontSize + "px " + options.font
+				);
+			}
 
 			if(options.textPosition == "top"){
 				y = options.fontSize - options.textMargin;
@@ -136,7 +198,9 @@ class SVGRenderer{
 		svg.setAttribute("xmlns", svgns);
 		svg.setAttribute("version", "1.1");
 
-		svg.setAttribute("style", "transform: translate(0,0)");
+		if (this.options.xmlDocument) {
+			svg.setAttribute("style", "transform: translate(0,0)");
+		}
 	}
 
 	createGroup(x, y, parent){
@@ -149,9 +213,11 @@ class SVGRenderer{
 	}
 
 	setGroupOptions(group, options){
-		group.setAttribute("style",
-			"fill:" + options.lineColor + ";"
-		);
+		if (options.xmlDocument) {
+			group.setAttribute("style",
+				"fill:" + options.lineColor + ";"
+			);
+		}
 	}
 
 	drawRect(x, y, width, height, parent){


### PR DESCRIPTION
Closes #450, closes #456

When used with a strict Content-Security-Policy, browsers will refuse to render the svg as inline styles are used.

The following error will be seen in console

`Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'nonce-nonce_placeholder'". Either the 'unsafe-inline' keyword, a hash ('sha256-eV8Xu0oi/phHwwFa2aajf5nivMeGhgQRxQsJ/TFjv+k='), or a nonce ('nonce-...') is required to enable inline execution`

This pull request moves the styles to a dynamically generated style tag and allows the nonce attribute be set to the `nonce` option value or attempts to get the nonce value from `<meta property="csp-nonce" nonce="nonce_placeholder" />`

This was tested using `example/cspNonce.html`. In an actual implementation the `Content-Security-Policy` header will be set by the server and the server will rewrite the `nonce_placeholder` value in the html file and not be set using `meta http-equiv`.