### PR TITLE
Avoid inline style in SVG

### DIFF
--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -89,9 +89,14 @@ class SVGRenderer{
 		if(options.displayValue){
 			var x, y;
 
-			textElem.setAttribute("style",
-				"font:" + options.fontOptions + " " + options.fontSize + "px " + options.font
-			);
+			textElem.setAttribute("font-family", options.font);
+			textElem.setAttribute("font-size", options.fontSize);
+			if (options.fontOptions.includes("bold")) {
+				textElem.setAttribute("font-weight", "bold");
+			}
+			if (options.fontOptions.includes("italic")) {
+				textElem.setAttribute("font-style", "italic");
+			}
 
 			if(options.textPosition == "top"){
 				y = options.fontSize - options.textMargin;

--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -45,7 +45,7 @@ class SVGRenderer{
 
 		if(this.options.background){
 			this.drawRect(0, 0, width, maxHeight, this.svg).setAttribute(
-				"style", "fill:" + this.options.background + ";"
+				"fill", this.options.background
 			);
 		}
 	}
@@ -135,8 +135,6 @@ class SVGRenderer{
 
 		svg.setAttribute("xmlns", svgns);
 		svg.setAttribute("version", "1.1");
-
-		svg.setAttribute("style", "transform: translate(0,0)");
 	}
 
 	createGroup(x, y, parent){
@@ -149,9 +147,7 @@ class SVGRenderer{
 	}
 
 	setGroupOptions(group, options){
-		group.setAttribute("style",
-			"fill:" + options.lineColor + ";"
-		);
+		group.setAttribute("fill", options.lineColor);
 	}
 
 	drawRect(x, y, width, height, parent){


### PR DESCRIPTION
fixes #450, fixes #456, alternative to #472

I noticed that most uses of inline style (which conflict with most Content Security Policies) are unnecessary, because SVG attributes can be used instead.

`fontOptions` is somewhat tricky because its contents can map to different SVG attributes. I implemented matching for "bold" and "italic" (as used in [the documentation](https://github.com/lindell/JsBarcode/wiki/Options#font-options)).